### PR TITLE
Use context manager to open PDFs

### DIFF
--- a/rag/app/document_loader.py
+++ b/rag/app/document_loader.py
@@ -3,7 +3,8 @@ import fitz  # PyMuPDF
 import docx
 
 def extract_text_from_pdf(file_path):
-    return "\n".join([page.get_text() for page in fitz.open(file_path)])
+    with fitz.open(file_path) as doc:
+        return "\n".join(page.get_text() for page in doc)
 
 def extract_text_from_txt(file_path):
     with open(file_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- use a `with` statement when reading PDFs in `extract_text_from_pdf`

## Testing
- `pytest -q`
- `python3 -m pip install -r rag/requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_686dfab371288333a7c535a039953740